### PR TITLE
adição de máscara de entrada nos campos Telefone, CPF e CNPJ

### DIFF
--- a/front_end_ang/package-lock.json
+++ b/front_end_ang/package-lock.json
@@ -29,6 +29,7 @@
         "front-end-ang": "file:",
         "ng2-currency-mask": "^13.0.3",
         "ngx-cookie-service": "^17.1.0",
+        "ngx-mask": "^18.0.0",
         "ngx-toastr": "^18.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -9501,6 +9502,19 @@
       "peerDependencies": {
         "@angular/common": "^17.0.0",
         "@angular/core": "^17.0.0"
+      }
+    },
+    "node_modules/ngx-mask": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-18.0.0.tgz",
+      "integrity": "sha512-9jR7cibNLiIrHDUYlIQb9yVImvLssE4LhvdKXdYzEanqupqjNuytkZBbLGDPjx6hOx8YdlL6jsSPV051cF6+PQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0",
+        "@angular/forms": ">=14.0.0"
       }
     },
     "node_modules/ngx-toastr": {

--- a/front_end_ang/package.json
+++ b/front_end_ang/package.json
@@ -36,6 +36,7 @@
     "front-end-ang": "file:",
     "ng2-currency-mask": "^13.0.3",
     "ngx-cookie-service": "^17.1.0",
+    "ngx-mask": "^18.0.0",
     "ngx-toastr": "^18.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/front_end_ang/src/app/app.module.ts
+++ b/front_end_ang/src/app/app.module.ts
@@ -48,6 +48,9 @@ import { PersistPaginatorDirective } from './PersistPaginator.directive';
 //import de acessibilidade
 import {A11yModule} from '@angular/cdk/a11y';
 
+//import de mascáras de entrada
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
+
 // configuracoes pre-definidas para o input "currencyMask" (ng2-currency-mask)
 export const CustomCurrencyMaskConfig: CurrencyMaskConfig = {
   align: "right",
@@ -101,6 +104,7 @@ export const CustomCurrencyMaskConfig: CurrencyMaskConfig = {
     , MatTooltipModule
     , CurrencyMaskModule
     ,A11yModule
+    , NgxMaskDirective
 
   ],
   providers: [
@@ -112,6 +116,7 @@ export const CustomCurrencyMaskConfig: CurrencyMaskConfig = {
     provideNativeDateAdapter()
     ,DatePipe
     ,CookieService
+    ,provideNgxMask()
   ],
   bootstrap: [AppComponent]
 })

--- a/front_end_ang/src/app/cliente-det/cliente-det.component.html
+++ b/front_end_ang/src/app/cliente-det/cliente-det.component.html
@@ -1,6 +1,6 @@
 
 <div class="form-group col-md-6  mx-auto" >
-  
+
 <h2 #h2 id="PageTitle" name="PageTitle">{{ this.PageTitle }}</h2>
 
 <!--&todo& talvez poderia vamos colocar um botao excluir para excluir o cliente que o usuario estiver vendo os detalhes (somente se estiver visualizando um cliente)-->
@@ -23,7 +23,7 @@
   <mat-form-field appearance="fill" class="" style="width: 50%">
     <mat-label>Telefone</mat-label>
     <input matInput type="text" id="Cad_Cliente_Telefone" name="Cad_Cliente_Telefone" formControlName="Cad_Cliente_Telefone"
-           [(ngModel)]="cliente.telefone" pattern="^[0123456789\-\(\)]+$" />
+           [(ngModel)]="cliente.telefone" pattern="^[0123456789\-\(\)]+$" mask="(00) 0000-0000||(00) 0 0000-0000"/>
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" class="" style="width: 100%">
@@ -33,25 +33,25 @@
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" style="width: 40%">
-    <mat-label>Tipo do cliente</mat-label> 
+    <mat-label>Tipo do cliente</mat-label>
     <mat-select #Cad_Cliente_Tipo id="Cad_Cliente_Tipo" name="Cad_Cliente_Tipo" formControlName="Cad_Cliente_Tipo"
                 [(value)]="cliente.tipo_cliente" required="true"
                 (ngModelChange)="on_Cad_Cliente_Tipo_Change($event)" >
       <mat-option value="Pessoa Física">Pessoa Física</mat-option>
       <mat-option value="Pessoa Jurídica">Pessoa Jurídica</mat-option>
-    </mat-select> 
+    </mat-select>
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" class="" style="width: 70%" [matTooltip]="tooltip_cpf" [matTooltipPosition]="'below'" >
     <mat-label>CPF</mat-label>
     <input #Cad_Cliente_CPF matInput type="text" id="Cad_Cliente_CPF" name="Cad_Cliente_CPF" formControlName="Cad_Cliente_CPF"
-           [(ngModel)]="cliente.cpf" pattern="^^[0123456789\.\-]+$" />
+           [(ngModel)]="cliente.cpf" pattern="^^[0123456789\.\-]+$" mask="000.000.000-00"/>
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" class="" style="width: 70%" [matTooltip]="tooltip_cnpj" [matTooltipPosition]="'below'" >
     <mat-label>CNPJ</mat-label>
     <input #Cad_Cliente_CNPJ matInput type="text" id="Cad_Cliente_CNPJ" name="Cad_Cliente_CNPJ" formControlName="Cad_Cliente_CNPJ"
-           [(ngModel)]="cliente.cnpj" pattern="^[0123456789\.\/\-]+$" />
+           [(ngModel)]="cliente.cnpj" pattern="^[0123456789\.\/\-]+$" mask="00.000.000/0000-00"/>
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" class="" style="width: 100%">
@@ -79,7 +79,7 @@
   </mat-form-field>
   <br />
   <mat-form-field appearance="fill" style="width: 20%">
-    <mat-label>Estado</mat-label> 
+    <mat-label>Estado</mat-label>
     <mat-select id="Cad_Cliente_Estado" name="Cad_Cliente_Estado" formControlName="Cad_Cliente_Estado"
                 [(value)]="cliente.uf" >
       <mat-option value="AC">AC</mat-option>
@@ -109,7 +109,7 @@
       <mat-option value="SP">SP</mat-option>
       <mat-option value="SE">SE</mat-option>
       <mat-option value="TO">TO</mat-option>
-    </mat-select> 
+    </mat-select>
   </mat-form-field>
   <div class="form-group">
     <button #SubmitButton type="submit" mat-raised-button color="primary" *ngIf="!IsInViewMode()" [disabled]="!cliente_form.valid"

--- a/front_end_ang/src/app/fornecedor-det/fornecedor-det.component.html
+++ b/front_end_ang/src/app/fornecedor-det/fornecedor-det.component.html
@@ -23,7 +23,7 @@
     <mat-form-field appearance="fill" class="" style="width: 50%">
       <mat-label>Telefone</mat-label>
       <input matInput type="text" id="Cad_fornecedor_Contato_Telefonico" name="Cad_fornecedor_Contato_Telefonico" formControlName="Cad_fornecedor_Contato_Telefonico"
-             [(ngModel)]="fornecedor.contato_telefonico" pattern="^[0123456789\-\(\)]+$" />
+             [(ngModel)]="fornecedor.contato_telefonico" pattern="^[0123456789\-\(\)]+$" mask="(00) 0000-0000||(00) 0 0000-0000" />
     </mat-form-field>
     <br />
     <mat-form-field appearance="fill" class="" style="width: 100%">
@@ -32,7 +32,7 @@
              [(ngModel)]="fornecedor.redes_sociais" />
     </mat-form-field>
     <br />
-    
+
     <mat-form-field appearance="fill" class="" style="width: 100%">
       <mat-label>Materiais Fornecidos</mat-label>
       <textarea id="Cad_fornecedor_Materiais_Fornecidos" name="Cad_fornecedor_Materiais_Fornecidos" formControlName="Cad_fornecedor_Materiais_Fornecidos"
@@ -43,7 +43,7 @@
     <mat-form-field appearance="fill" class="" style="width: 70%">
       <mat-label>CNPJ</mat-label>
       <input matInput type="text" id="Cad_fornecedor_CNPJ" name="Cad_fornecedor_CNPJ" formControlName="Cad_fornecedor_CNPJ"
-             [(ngModel)]="fornecedor.cnpj" pattern="^[0123456789\.\/\-]+$" />
+             [(ngModel)]="fornecedor.cnpj" pattern="^[0123456789\.\/\-]+$" mask="00.000.000/0000-00" />
     </mat-form-field>
     <br />
     <mat-form-field appearance="fill" class="" style="width: 100%">

--- a/front_end_ang/src/app/fornecedor-list/fornecedor-list.component.html
+++ b/front_end_ang/src/app/fornecedor-list/fornecedor-list.component.html
@@ -27,7 +27,7 @@
                Nome
           </th>
         <td mat-cell *matCellDef="let element">
-          <a href='{{"/fornecedor-det/" + element.id_fornecedor + "?mode=V"}}'>{{ element.nome_fornecedor}}</a>   
+          <a href='{{"/fornecedor-det/" + element.id_fornecedor + "?mode=V"}}'>{{ element.nome_fornecedor}}</a>
         </td>
     </ng-container>
 


### PR DESCRIPTION
adição de máscara de entrada nos campos telefone, CPF e CNPJ dos formulários fornecedor-det e cliente-de utilizando módulo ngx-mask. O fornecedor-list está presente pois ele apresenta os campos na tabela sem formatação e não consegui entender o porque já que eles são obtidos de forma semelhante ao cliente-list que exibe os dados com formatação. Não sei porque o vs code marca linhas que não foram alteradas se for alguma configuração por favor me avisem.