### PR TITLE
parse raw value to float instead of formattedValue

### DIFF
--- a/front_end_ang/src/app/vendas-graf/vendas-graf.component.ts
+++ b/front_end_ang/src/app/vendas-graf/vendas-graf.component.ts
@@ -104,11 +104,8 @@ export class VendasGrafComponent implements OnInit {
         }
         ,tooltip: {
           callbacks: {
-              label: function(tooltipItem : any) {
-                // formatar o numero como moeda R$ quando for exibir o tooltip dos pontos do grafico
-                let value = Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(parseFloat(tooltipItem.formattedValue));
-                return value;
-              }
+              // formatar o numero como moeda R$ quando for exibir o tooltip dos pontos do grafico
+              label: (tooltipItem : any) => Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(parseFloat(tooltipItem.raw))
           }
         }
       },


### PR DESCRIPTION
Utilizando o campo raw pra transformar em float e ser formatado para real, assim garantindo consistencia entre navegadores.
o campo raw eu entendo ser o q vem direto da api e portanto eh um float, assim como esperado pela funcao parseFloat.

Mozila firefox, formattedValue fica `1.144`: 
![image](https://github.com/user-attachments/assets/1e89e120-65bb-401d-9a37-9376ab4af07c)
Chrome, formattedValue fica `144`:
![image](https://github.com/user-attachments/assets/0bb8e99e-79e5-4b64-9376-fdcb96ff3582)
