### PR TITLE
[BUG] Valores negativos número de pedido

### DIFF
--- a/front_end_ang/src/app/produto-saida/produto-saida.component.html
+++ b/front_end_ang/src/app/produto-saida/produto-saida.component.html
@@ -88,9 +88,9 @@
     <!-- Campo de entrada do número do pedido -->
     <mat-form-field appearance="fill" style="width: 20%">
       <mat-label>Núm. Pedido</mat-label>
-      <input type="number" id="NumPedidoInput" name="NumPedidoInput" formControlName="NumPedidoInput" (keypress)="permitirSomenteNumeros($event)"
+      <input type="number" id="NumPedidoInput" name="NumPedidoInput" formControlName="NumPedidoInput"
              matInput min="1" step="1" pattern="^[0-9]+$"
-             matInput [(ngModel)]="movimentacao.num_pedido"
+             [(ngModel)]="movimentacao.num_pedido"
              [attr.aria-label]="'Insira o número do pedido'" />
     </mat-form-field>
 

--- a/front_end_ang/src/app/produto-saida/produto-saida.component.html
+++ b/front_end_ang/src/app/produto-saida/produto-saida.component.html
@@ -88,7 +88,8 @@
     <!-- Campo de entrada do número do pedido -->
     <mat-form-field appearance="fill" style="width: 20%">
       <mat-label>Núm. Pedido</mat-label>
-      <input type="number" id="NumPedidoInput" name="NumPedidoInput" formControlName="NumPedidoInput"
+      <input type="number" id="NumPedidoInput" name="NumPedidoInput" formControlName="NumPedidoInput" (keypress)="permitirSomenteNumeros($event)"
+             matInput min="1" step="1" pattern="^[0-9]+$"
              matInput [(ngModel)]="movimentacao.num_pedido"
              [attr.aria-label]="'Insira o número do pedido'" />
     </mat-form-field>

--- a/front_end_ang/src/app/produto-saida/produto-saida.component.ts
+++ b/front_end_ang/src/app/produto-saida/produto-saida.component.ts
@@ -226,14 +226,6 @@ export class ProdutoSaidaComponent implements OnInit {
     }
   }
 
-  permitirSomenteNumeros(event: KeyboardEvent) {
-    const charCode = event.charCode;
-    // Permitir apenas caracteres de '0' a '9'
-    if (charCode < 48 || charCode > 57) {
-      event.preventDefault();
-    }
-  }
-
   voltar(): void {
     this.location.back();
   }

--- a/front_end_ang/src/app/produto-saida/produto-saida.component.ts
+++ b/front_end_ang/src/app/produto-saida/produto-saida.component.ts
@@ -226,6 +226,14 @@ export class ProdutoSaidaComponent implements OnInit {
     }
   }
 
+  permitirSomenteNumeros(event: KeyboardEvent) {
+    const charCode = event.charCode;
+    // Permitir apenas caracteres de '0' a '9'
+    if (charCode < 48 || charCode > 57) {
+      event.preventDefault();
+    }
+  }
+
   voltar(): void {
     this.location.back();
   }


### PR DESCRIPTION
Why: Números negativos podem ser selecionados ou escritos por meio do teclado no campo Número do Pedido na tela de saída de produtos
How: Alterar as configurações do do input do mat form field para não permitir a inserção de números negativos por meio do selector e do teclado