### PR TITLE
fix: mes vazio no graf vendas

### DIFF
--- a/back_end/index.js
+++ b/back_end/index.js
@@ -889,9 +889,11 @@ app.get('/vendas_graf_por_periodo', (req, res) => {
   const query = "select DATE_FORMAT(t.data_hora, '%Y/%m') as \"mes\", sum(t.quantidade * p.preco_venda) valor_total " +
                 "from movimentacao t " +
                 "join produto p on (p.id_produto = t.id_produto) " +
-                "where ( t.tipo_mov = 'E' ) " +
+                "where ( t.tipo_mov = 'S' )" + // considerar apenas saidas de estoque
+                "AND ( t.data_hora BETWEEN ? AND ? ) " + // pegar as movimentacoes de saida apenas que tiverem data_hora dentro do periodo
                 "group by mes, t.tipo_mov " +
                 "order by mes asc " ;
+  //console.log("query=" + query);
   const values = [ req.query.dhinicio , req.query.dhfim ];
   db.query(query, values, (err, results) => {
     if (err) {

--- a/front_end_ang/src/app/vendas-graf/vendas-graf.component.ts
+++ b/front_end_ang/src/app/vendas-graf/vendas-graf.component.ts
@@ -231,17 +231,30 @@ export class VendasGrafComponent implements OnInit {
 
         this.data.datasets[0].data[char_x_idx] = this.graf_data[i].valor_total;
 
-        const tabelaData = this.data.labels.map((mes: string, index: number) => ({
-          mes: mes,
-          valor: this.data.datasets[0].data[index]
-        }));
-
-        // Atribuir os dados à tabela
-        this.tabelaVendas.data = tabelaData;
-
-
-
       } // for
+
+      //console.log("this.graf_data=" + JSON.stringify(this.graf_data) );
+      
+      //console.log("this.data.datasets[0].data=" + JSON.stringify( this.data.datasets[0].data) );
+
+      // passar pelo this.data.datasets[0].data e colocar zero onde tiver null, considerando a qtde de meses do grafico
+      // (fica null nos meses que nao teve venda)
+      for (let i = 0; i < qtde_months; i++) {
+        if ( this.data.datasets[0].data[i] == null) {
+          this.data.datasets[0].data[i] = 0;
+        }
+      } // for
+
+      //console.log("this.data.datasets[0].data=" + JSON.stringify( this.data.datasets[0].data) );
+
+      // montar "tableData" que serah o datasource para a tabela
+      const tabelaData = this.data.labels.map((mes: string, index: number) => ({
+        mes: mes,
+        valor: this.data.datasets[0].data[index]
+      }));
+
+      // Atribuir os dados à tabela
+      this.tabelaVendas.data = tabelaData;
 
       // atualizar o grafico
       this.chart.refresh();


### PR DESCRIPTION
O Gráfico de Vendas foi corrigido e agora os meses com zero vendas mostram zero mesmo, pois antes ficava null no array interno de dados e o gráfico e a tabela mostravam vazio nos meses sem vendas. O bloco das linhas 250 ~ 257 foi movido para depois (fora) do for porque não precisa ficar dentro do for. No back-end foi corrigido um bug que havia no SELECT do endpoint "/vendas_graf_por_periodo".

Antes ficava como vemos abaixo, no mês 12.

![image](https://github.com/user-attachments/assets/b7f65161-7097-4ae9-851a-72d74c8c295d)

Agora fica assim como vemos abaixo. Note que no mês 12 agora tem o ponto do gráfico com valor zero.

![image](https://github.com/user-attachments/assets/6db8c26d-feda-43d3-8d56-67a4ec965f3a)
