### PR TITLE
C24 adic msg toastr erro exclusao cliente produto

### DIFF
--- a/front_end_ang/src/app/cliente-list/cliente-list.component.ts
+++ b/front_end_ang/src/app/cliente-list/cliente-list.component.ts
@@ -79,9 +79,13 @@ public GetEditarLink = Utils.GetEditarLink;
         this.fetchData(); // Recarregar os itens após a exclusão
       },
       (error) => {
-        console.error('Erro ao deletar post:', error.error);
+        console.error('Erro ao deletar cliente:', error.error);
         // error.error contém a mensagem de erro enviada pelo servidor
-        alert(error.error);
+        //alert(error.error);
+        this.toastr.error(error.error , 'Erro', {
+          disableTimeOut: true
+          ,positionClass: 'toast-top-center'
+        });
       }); // subscribe
     } // confirm
   } // excluirCliente

--- a/front_end_ang/src/app/produto-list/produto-list.component.ts
+++ b/front_end_ang/src/app/produto-list/produto-list.component.ts
@@ -93,9 +93,14 @@ export class ProdutoListComponent implements OnInit {
         this.fetchData(); // Recarregar os itens após a exclusão
       },
       (error) => {
-        console.error('Erro ao deletar post:', error.error);
+        console.error('Erro ao deletar produto:', error.error);
         // error.error contém a mensagem de erro enviada pelo servidor
-        alert(error.error);
+        //alert(error.error);
+        // avisar o usuario
+        this.toastr.error(error.error , 'Erro', {
+          disableTimeOut: true
+          ,positionClass: 'toast-top-center'
+        });
       }); // subscribe
     } // confirm
   } // excluirItem

--- a/front_end_ang/src/styles.scss
+++ b/front_end_ang/src/styles.scss
@@ -226,3 +226,8 @@ li  a[disabled=true] {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+/* aumentar a largura das msgs de erro exibidas com o package "toastr" */
+.toast-error {
+  width: 500px !important;
+}


### PR DESCRIPTION
As msgs de erro que aparecem para o usuário quando ocorre erro na exclusão de cliente e de produto porque o cliente ou o produto já foram utilizados em alguma movimentação foram melhoradas e agora não são mais exibidas com simples alert's.
Ver abaixo como era a msg que aparecia antes:

![image](https://github.com/user-attachments/assets/c354fcf3-91c0-44fd-b1c9-f8c9309888c7)

A exibição destas msgs agora é feita com o package "toastr" e a msg é exibida na cor vermelha e fica na tela até o usuário clicar na msg para ela ser fechada. Ver abaixo:

![Imagem do WhatsApp de 2025-04-23 à(s) 21 15 49_0666271b](https://github.com/user-attachments/assets/5bb1ab9c-13d8-47b3-9767-29f4b5234c30)
