### PR TITLE
Feature/c89 graf vendas por cliente - melhoria na legenda

### DIFF
--- a/front_end_ang/src/app/vendas-cli-graf/vendas-cli-graf.component.ts
+++ b/front_end_ang/src/app/vendas-cli-graf/vendas-cli-graf.component.ts
@@ -78,7 +78,7 @@ export class VendasCliGrafComponent implements OnInit {
       datasets: [
         {
           order: 2,
-          label: 'Vendas (R$)',
+          label: 'Vendas em R$',
           yAxisID: 'y',
           type: 'bar',
           backgroundColor: '#208104', // verde
@@ -88,7 +88,7 @@ export class VendasCliGrafComponent implements OnInit {
         ,
         {
           order: 1,
-          label: '%',
+          label: '% de Vendas',
           yAxisID: 'y1',
           type: 'line',
           tension: 0.4,


### PR DESCRIPTION
Antes a legenda do gráfico estava assim:

![Imagem do WhatsApp de 2025-05-13 à(s) 18 13 03_cbb566b5](https://github.com/user-attachments/assets/0160b2eb-91d6-4ce4-bb40-6e53be07eb8f)

E agora a legenda ficou assim:

![image](https://github.com/user-attachments/assets/c192a3a6-e4c5-4188-abd2-f67437734749)

